### PR TITLE
Update mock storage

### DIFF
--- a/EdvClient.js
+++ b/EdvClient.js
@@ -864,7 +864,6 @@ export class EdvClient {
         (doc.indexed || []),
       cipher.encryptObject({obj, recipients, keyResolver})
     ]);
-
     delete encrypted.content;
     delete encrypted.meta;
     delete encrypted.stream;

--- a/tests/10-EdvClient.spec.js
+++ b/tests/10-EdvClient.spec.js
@@ -46,7 +46,6 @@ describe('EdvClient', () => {
     });
     version1 = await client.get({id: doc.id, invocationSigner});
 
-    // console.log("version: 1", version1);
     await client.update({
       doc: {
         ...version1,
@@ -59,7 +58,6 @@ describe('EdvClient', () => {
       keyResolver
     });
     const version2 = await client.get({id: doc.id, invocationSigner});
-    // console.log("version: 2", version2);
     await client.update({
       doc: {
         ...version2,

--- a/tests/10-EdvClient.spec.js
+++ b/tests/10-EdvClient.spec.js
@@ -17,7 +17,6 @@ describe('EdvClient', () => {
   });
 
   it('should find document by index after updates', async () => {
-
     const client = await mock.createEdv();
     client.ensureIndex({attribute: 'content.indexedKey'});
     const testId = await EdvClient.generateId();

--- a/tests/MockStorage.js
+++ b/tests/MockStorage.js
@@ -180,8 +180,18 @@ export class MockStorage {
         }
       }
     }
-
+    const oldDoc = edv.documents.get(doc.id);
     edv.documents.set(doc.id, doc);
+    if(oldDoc) {
+      // if an indexed value was not updated
+      // it's attributes is an empty array.
+      // so we need to use the last attributes.
+      for(const index in doc.indexed) {
+        if(doc.indexed[index].attributes.length === 0) {
+          doc.indexed[index].attributes = oldDoc.indexed[index].attributes;
+        }
+      }
+    }
     for(const entry of doc.indexed) {
       let index = edv.indexes.get(entry.hmac.id);
       if(!index) {
@@ -216,6 +226,13 @@ export class MockStorage {
     if(unique) {
       docSet.clear();
     }
+    // This emulates an update in the database.
+    docSet.forEach(d => {
+      const older = (d.id === doc.id) && (d.sequence < doc.sequence);
+      if(older) {
+        docSet.delete(d);
+      }
+    });
     docSet.add(doc);
   }
 

--- a/tests/MockStorage.js
+++ b/tests/MockStorage.js
@@ -181,17 +181,11 @@ export class MockStorage {
       }
     }
     const oldDoc = edv.documents.get(doc.id);
-    edv.documents.set(doc.id, doc);
     if(oldDoc) {
-      // if an indexed value was not updated
-      // it's attributes is an empty array.
-      // so we need to use the last attributes.
-      for(const index in doc.indexed) {
-        if(doc.indexed[index].attributes.length === 0) {
-          doc.indexed[index].attributes = oldDoc.indexed[index].attributes;
-        }
-      }
+      // remove old doc from indexes on update.
+      this.unindex({edv, doc: oldDoc});
     }
+    edv.documents.set(doc.id, doc);
     for(const entry of doc.indexed) {
       let index = edv.indexes.get(entry.hmac.id);
       if(!index) {
@@ -226,13 +220,6 @@ export class MockStorage {
     if(unique) {
       docSet.clear();
     }
-    // This emulates an update in the database.
-    docSet.forEach(d => {
-      const older = (d.id === doc.id) && (d.sequence < doc.sequence);
-      if(older) {
-        docSet.delete(d);
-      }
-    });
     docSet.add(doc);
   }
 


### PR DESCRIPTION
Addresses a bug found by Orie in the unit tests: https://github.com/digitalbazaar/edv-client/issues/17

1. Attributes are added to updated indexes if no updated attributes were found.
2. Ensure the indexed document is the latest version of the document.
3. Adds 2 tests from Orie that ensure the test framework works as expected.


```sh
EdvClient
    ✓ should only contain one indexed document after 3 updates (91ms)
    ✓ should have matching sequence numbers in indexes
    ✓ should create a new encrypted data vault
    ✓ should get an encrypted data vault config
    ✓ should create "primary" encrypted data vault
    ✓ should get "primary" encrypted data vault
    ✓ should ensure two new indexes
    ✓ should insert a document
    ✓ should get a document
    ✓ should fail to get a non-existent document
    ✓ should fail to insert a duplicate document
    ✓ should upsert a document
    ✓ should update an existing document
    ✓ should delete an existing document
    ✓ should fail to delete a non-existent document
    ✓ should insert a document with attributes
    ✓ should reject two documents with same unique attribute
    ✓ should find a document that has an attribute
    ✓ should find two documents with an attribute
    ✓ should find a document that equals an attribute value
    ✓ should find a document that equals the value of a URL attribute
    ✓ should find a document with a deep index on an array
    ✓ should find two documents with attribute values

  EdvDocument
    ✓ should read a document using EdvDocument


  24 passing (461ms)
```