### PR TITLE
Fix coverage reports.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,5 +69,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        file: ./coverage.lcov
+        file: ./coverage/lcov.info
         fail_ci_if_error: true

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} --require tests/test-mocha.js tests/*.spec.js",
     "test-karma": "karma start karma.conf.js",
     "test-watch": "cross-env NODE_ENV=test mocha -r esm --watch --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} --require tests/test-mocha.js tests/*.spec.js",
-    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text npm run test-node",
-    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=text-lcov npm run test-node > coverage.lcov",
+    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
+    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm run test-node",
     "coverage-report": "nyc report",
     "lint": "eslint ."
   },
@@ -102,10 +102,6 @@
   "nyc": {
     "exclude": [
       "tests"
-    ],
-    "reporter": [
-      "html",
-      "text-summary"
     ]
   }
 }


### PR DESCRIPTION
- Use lcovonly and default report for coverage-ci script.
- Use text-summary for coverage output.
- Remove unneeded default reporters.

I don't know what people like for the default output.  This uses basic "text-summary" reporter for "coverage" and more verbose "text" reporter for "coverage-report".  Thoughts?

Fixes https://github.com/digitalbazaar/edv-client/issues/55.