### PR TITLE
Tombstone for deleted edv documents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # edv-client ChangeLog
 
-## 5.0.0 - 2020-07-13
+## 5.0.0 - TBD
 
 ### Changed
 - **BREAKING**: Change deletion to remove all content but retain `id` and `sequence`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # edv-client ChangeLog
 
-## 4.1.0 - 2020-07-09
+## 5.0.0 - 2020-07-13
 
 ### Changed
 - **BREAKING**: Change deletion to remove all content but retain `id` and `sequence`.
-- **BREAKING**: `keyResolver` must be passed as an argument to `delete`.
+- **BREAKING**: `doc` and `keyResolver` must be passed as an argument to `delete`.
 
 ## 4.0.1 - 2020-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # edv-client ChangeLog
 
+## 4.1.0 - 2020-07-09
+
+### Changed
+- **BREAKING**: Change deletion to remove all content but retain `id` and `sequence`.
+- **BREAKING**: `keyResolver` must be passed as an argument to `delete`.
+
 ## 4.0.1 - 2020-06-22
 
 ### Fixed

--- a/EdvClient.js
+++ b/EdvClient.js
@@ -383,9 +383,9 @@ export class EdvClient {
     doc.meta.deleted = true;
 
     try {
-      await this.update({doc, keyResolver,
-        keyAgreementKey,
-        capability, invocationSigner});
+      await this.update({
+        doc, keyResolver, keyAgreementKey, capability, invocationSigner
+      });
     } catch(e) {
       return false;
     }

--- a/EdvClient.js
+++ b/EdvClient.js
@@ -371,26 +371,21 @@ export class EdvClient {
     _assertString(doc.id, '"id" must be a string.');
     _assertInvocationSigner(invocationSigner);
 
+    doc = {...doc};
     doc.content = {};
     if(!doc.meta) {
       doc.meta = {};
+    } else {
+      doc.meta = {...doc.meta};
     }
     doc.meta.deleted = true;
+    delete doc.stream;
 
-    try {
-      await this.update({
-        doc, recipients, keyResolver, keyAgreementKey, capability,
-        invocationSigner
-      });
-    } catch(e) {
-      const {response = {}} = e;
-      if(response.status === 409) {
-        const err = new Error('Conflict error.');
-        err.name = 'InvalidStateError';
-        throw err;
-      }
-      throw e;
-    }
+    await this.update({
+      doc, recipients, keyResolver, keyAgreementKey, capability,
+      invocationSigner
+    });
+
     return true;
   }
 

--- a/EdvClient.js
+++ b/EdvClient.js
@@ -28,19 +28,19 @@ export class EdvClient {
    * <authority>/edvs/<random multibase base58 encoded ID>
    *
    * @param {Object} options - The options to use.
-   * @param {string} [id=undefined] the ID of the EDV that must be a URL
+   * @param {string} [id=undefined] - The ID of the EDV that must be a URL
    *   that refers to the EDV's root storage location; if not given, then
    *   a separate capability must be given to each method called on the client
    *   instance.
-   * @param {function} [keyResolver=this.keyResolver] a default function that
+   * @param {function} [keyResolver=this.keyResolver] - A default function that
    *   returns a Promise that resolves a key ID to a DH public key.
-   * @param {Object} [keyAgreementKey=null] a default KeyAgreementKey API for
+   * @param {Object} [keyAgreementKey=null] - A default KeyAgreementKey API for
    *   deriving shared KEKs for wrapping content encryption keys.
-   * @param {Object} [hmac=null] a default HMAC API for blinding indexable
+   * @param {Object} [hmac=null] - A default HMAC API for blinding indexable
    *   attributes.
-   * @param {https.Agent} [httpsAgent=undefined] an optional HttpsAgent to
+   * @param {https.Agent} [httpsAgent=undefined] - An optional HttpsAgent to
    *   use to handle HTTPS requests.
-   * @param {Object} [defaultHeaders=undefined] an optional defaultHeaders
+   * @param {Object} [defaultHeaders=undefined] - An optional defaultHeaders
    *   object to use with HTTP requests.
    *
    * @return {EdvClient}.
@@ -66,9 +66,9 @@ export class EdvClient {
    * providing an array for `attribute`.
    *
    * @param {Object} options - The options to use.
-   * @param {string|Array} options.attribute the attribute name or an array of
+   * @param {string|Array} options.attribute - The attribute name or an array of
    *   attribute names to create a unique compound index.
-   * @param {boolean} [options.unique=false] `true` if the index should be
+   * @param {boolean} [options.unique=false] Should be `true` if the index is
    *   considered unique, `false` if not.
    */
   ensureIndex({attribute, unique = false}) {
@@ -84,27 +84,27 @@ export class EdvClient {
    * including a message digest.
    *
    * @param {Object} options - The options to use.
-   * @param {Object} options.doc the document to insert.
-   * @param {Readable} [options.stream] a WHATWG Readable stream to read
+   * @param {Object} options.doc - The document to insert.
+   * @param {Readable} [options.stream] - A WHATWG Readable stream to read
    *   from to associate chunked data with this document.
-   * @param {number} [chunkSize=1048576] the size, in bytes, of the chunks to
+   * @param {number} [chunkSize=1048576] - The size, in bytes, of the chunks to
    *   break the incoming stream data into.
-   * @param {Object} [options.recipients=[]] a set of JWE recipients to encrypt
-   *   the document for; if not present, a default recipient will be added
-   *   using `this.keyAgreementKey` and if no `keyAgreementKey` is set, an
-   *   error will be thrown.
-   * @param {function} [keyResolver=this.keyResolver] a function that returns
+   * @param {Object} [options.recipients=[]] - A set of JWE recipients
+   *   to encrypt the document for; if not present, a default recipient will
+   *   be added using `this.keyAgreementKey` and if no `keyAgreementKey` is
+   *   set, an error will be thrown.
+   * @param {function} [keyResolver=this.keyResolver] - A function that returns
    *   a Promise that resolves a key ID to a DH public key.
-   * @param {Object} [keyAgreementKey=null] a default KeyAgreementKey API for
+   * @param {Object} [keyAgreementKey=null] - A default KeyAgreementKey API for
    *   deriving shared KEKs for wrapping content encryption keys.
-   * @param {Object} [options.hmac=this.hmac] an HMAC API for blinding
+   * @param {Object} [options.hmac=this.hmac] - An HMAC API for blinding
    *   indexable attributes.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
    * @param {Object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<Object>} resolves to the inserted document.
+   * @return {Promise<Object>} Resolves to the inserted document.
    */
   async insert({
     doc, stream, chunkSize, recipients = [], keyResolver = this.keyResolver,
@@ -198,27 +198,27 @@ export class EdvClient {
    * information such as the stream data's message digest.
    *
    * @param {Object} options - The options to use.
-   * @param {Object} options.doc the document to insert.
-   * @param {Readable} [options.stream] a WHATWG Readable stream to read
+   * @param {Object} options.doc - The document to insert.
+   * @param {Readable} [options.stream] - A WHATWG Readable stream to read
    *   from to associate chunked data with this document.
-   * @param {number} [chunkSize=1048576] the size, in bytes, of the chunks to
+   * @param {number} [chunkSize=1048576] - The size, in bytes, of the chunks to
    *   break the incoming stream data into.
-   * @param {Object} [options.recipients=[]] a set of JWE recipients to encrypt
-   *   the document for; if present, recipients will be added to any existing
-   *   recipients; to remove existing recipients, modify the
-   *   `encryptedDoc.jwe.recipients` field.
-   * @param {function} [keyResolver=this.keyResolver] a function that returns
+   * @param {Object} [options.recipients=[]] - A set of JWE recipients
+   *   to encrypt the document for; if present, recipients will be added
+   *   to any existing recipients; to remove existing recipients, modify
+   *   the `encryptedDoc.jwe.recipients` field.
+   * @param {function} [keyResolver=this.keyResolver] - A function that returns
    *   a Promise that resolves a key ID to a DH public key.
-   * @param {Object} [keyAgreementKey=null] a default KeyAgreementKey API for
+   * @param {Object} [keyAgreementKey=null] - A default KeyAgreementKey API for
    *   deriving shared KEKs for wrapping content encryption keys.
-   * @param {Object} [options.hmac=this.hmac] an HMAC API for blinding
+   * @param {Object} [options.hmac=this.hmac] - An HMAC API for blinding
    *   indexable attributes.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
    * @param {Object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<Object>} resolves to the updated document.
+   * @return {Promise<Object>} Resolves to the updated document.
    */
   async update({
     doc, stream, chunkSize, recipients = [], keyResolver = this.keyResolver,
@@ -300,7 +300,8 @@ export class EdvClient {
    * existing entry for the index, it will be added.
    *
    * @param {Object} options - The options to use.
-   * @param {Object} options.doc the document to create or update an index for.
+   * @param {Object} options.doc - The document to create or update an index
+   *   for.
    * @param {Object} [options.hmac=this.hmac] an HMAC API for blinding
    *   indexable attributes.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
@@ -308,7 +309,7 @@ export class EdvClient {
    * @param {Object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise} resolves once the operation completes.
+   * @return {Promise} Resolves once the operation completes.
    */
   async updateIndex({doc, hmac = this.hmac, capability, invocationSigner}) {
     _assertDocument(doc);
@@ -347,22 +348,22 @@ export class EdvClient {
    * Deletes a document from the EDV.
    *
    * @param {Object} options - The options to use.
-   * @param {string} options.doc the document to delete.
-   * @param {Object} [options.recipients=[]] a set of JWE recipients to encrypt
-   *   the document for; if present, recipients will be added to any existing
-   *   recipients; to remove existing recipients, modify the
-   *   `encryptedDoc.jwe.recipients` field.
+   * @param {string} options.doc - The document to delete.
+   * @param {Object} [options.recipients=[]] - A set of JWE recipients to
+   *   encrypt the document for; if present, recipients will be added to
+   *   any existing recipients; to remove existing recipients, modify
+   *   the `encryptedDoc.jwe.recipients` field.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
    * @param {Object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
-   * @param {function} [keyResolver=this.keyResolver] a function that returns
+   * @param {function} [keyResolver=this.keyResolver] - A function that returns
    *   a Promise that resolves a key ID to a DH public key.
-   * @param {Object} [keyAgreementKey=null] a default KeyAgreementKey API for
+   * @param {Object} [keyAgreementKey=null] - A default KeyAgreementKey API for
    *   deriving shared KEKs for wrapping content encryption keys.
    *
-   * @return {Promise<Boolean>} resolves to `true` when the document was
-   *  deleted.
+   * @return {Promise<Boolean>} Resolves to `true` when the document was
+   *   deleted.
    */
   async delete({
     doc, recipients = [], capability, invocationSigner,
@@ -393,8 +394,8 @@ export class EdvClient {
    * Gets a document from the EDV by its ID.
    *
    * @param {Object} options - The options to use.
-   * @param {string} options.id the ID of the document to get.
-   * @param {Object} [options.keyAgreementKey=this.keyAgreementKey] a
+   * @param {string} options.id - The ID of the document to get.
+   * @param {Object} [options.keyAgreementKey=this.keyAgreementKey] - A
    *   KeyAgreementKey API for deriving a shared KEK to unwrap the content
    *   encryption key.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
@@ -402,7 +403,7 @@ export class EdvClient {
    * @param {Object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<Object>} resolves to the document.
+   * @return {Promise<Object>} Resolves to the document.
    */
   async get({
     id, keyAgreementKey = this.keyAgreementKey, capability, invocationSigner
@@ -442,8 +443,8 @@ export class EdvClient {
    * document.
    *
    * @param {Object} options - The options to use.
-   * @param {string} options.doc the document to get a stream for.
-   * @param {Object} [options.keyAgreementKey=this.keyAgreementKey] a
+   * @param {string} options.doc - The document to get a stream for.
+   * @param {Object} [options.keyAgreementKey=this.keyAgreementKey] - A
    *   KeyAgreementKey API for deriving a shared KEK to unwrap the content
    *   encryption key.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
@@ -451,7 +452,7 @@ export class EdvClient {
    * @param {Object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<ReadableStream>} resolves to a `ReadableStream` to read
+   * @return {Promise<ReadableStream>} Resolves to a `ReadableStream` to read
    *   the chunked data from.
    */
   async getStream({
@@ -495,10 +496,10 @@ export class EdvClient {
    * @see find - For more detailed documentation on the search options.
    *
    * @param {object} options - The options to use.
-   * @param {object} [options.keyAgreementKey=this.keyAgreementKey] a
+   * @param {object} [options.keyAgreementKey=this.keyAgreementKey] - A
    *   KeyAgreementKey API for deriving a shared KEK to unwrap the content
    *   encryption key.
-   * @param {object} [options.hmac=this.hmac] an HMAC API for blinding
+   * @param {object} [options.hmac=this.hmac] - An HMAC API for blinding
    *   indexable attributes.
    * @param {object|Array} [options.equals] - An object with key-value
    *   attribute pairs to match or an array of such objects.
@@ -509,7 +510,7 @@ export class EdvClient {
    * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<number>} resolves to the number of matching documents.
+   * @return {Promise<number>} Resolves to the number of matching documents.
   */
   async count({
     keyAgreementKey = this.keyAgreementKey, hmac = this.hmac, equals, has,
@@ -539,10 +540,10 @@ export class EdvClient {
    * contain documents that possess *all* of the attributes listed.
    *
    * @param {Object} options - The options to use.
-   * @param {Object} [options.keyAgreementKey=this.keyAgreementKey] a
+   * @param {Object} [options.keyAgreementKey=this.keyAgreementKey] - A
    *   KeyAgreementKey API for deriving a shared KEK to unwrap the content
    *   encryption key.
-   * @param {object} [options.hmac=this.hmac] an HMAC API for blinding
+   * @param {object} [options.hmac=this.hmac]  - An HMAC API for blinding
    *   indexable attributes.
    * @param {object|Array} [options.equals] - An object with key-value
    *   attribute pairs to match or an array of such objects.
@@ -553,7 +554,8 @@ export class EdvClient {
    * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<object>} the matching documents: {documents: [...]}.
+   * @return {Promise<object>} Resolves to the matching documents:
+   *   {documents: [...]}.
    */
   async find({
     keyAgreementKey = this.keyAgreementKey, hmac = this.hmac, equals, has,
@@ -602,13 +604,13 @@ export class EdvClient {
    * it to be invoked by its designated invoker.
    *
    * @param {Object} options - The options to use.
-   * @param {Object} options.capabilityToEnable the capability to enable.
+   * @param {Object} options.capabilityToEnable - The capability to enable.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
    * @param {Object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @returns {Promise<undefined>} resolves once the operation completes.
+   * @returns {Promise<undefined>} Resolves once the operation completes.
    */
   async enableCapability({capabilityToEnable, capability, invocationSigner}) {
     _assertObject(capabilityToEnable);
@@ -643,13 +645,13 @@ export class EdvClient {
    * EDV, preventing it from being invoked by its designated invoker.
    *
    * @param {Object} options - The options to use.
-   * @param {Object} options.id the ID of the capability to revoke.
+   * @param {Object} options.id - The ID of the capability to revoke.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
    * @param {Object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<Boolean>} resolves to `true` if the capability was
+   * @return {Promise<Boolean>} Resolves to `true` if the capability was
    *   disabled and `false` if it did not exist.
    */
   async disableCapability({id, capability, invocationSigner}) {
@@ -699,7 +701,8 @@ export class EdvClient {
    * @param {string|object} [options.capability] - A zCap authorizing the
    *   creation of an EDV. Defaults to a root capability derived from
    *   the `url` parameter.
-   * @return {Promise<Object>} resolves to the configuration for the newly
+   *
+   * @return {Promise<Object>} Resolves to the configuration for the newly
    *   created EDV.
    */
   static async createEdv({
@@ -761,7 +764,7 @@ export class EdvClient {
    *   access to an EDV config. Defaults to a root capability derived from
    *   the `url` parameter.
    *
-   * @return {Promise<Object>} resolves to the EDV configuration
+   * @return {Promise<Object>} Resolves to the EDV configuration
    *   containing the given controller and reference ID.
    */
   static async findConfig({
@@ -782,7 +785,7 @@ export class EdvClient {
    * @param {string} options.url - The url to query.
    * @param {string} options.controller - The EDV's controller.
    * @param {string} [options.referenceId] - A controller-unique reference ID.
-   * @param {string} [options.after] - A EDV's ID.
+   * @param {string} [options.after] - An EDV's ID.
    * @param {number} [options.limit] - How many EDV configs to return.
    * @param {https.Agent} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
@@ -794,7 +797,7 @@ export class EdvClient {
    *   access to an EDV config. Defaults to a root capability derived from
    *   the `url` parameter.
    *
-   * @return {Promise<Array>} resolves to the matching EDV configurations.
+   * @return {Promise<Array>} Resolves to the matching EDV configurations.
    */
   static async findConfigs({
     url = '/edvs', controller, referenceId, after, limit, httpsAgent, headers,
@@ -843,13 +846,13 @@ export class EdvClient {
    * Gets the configuration for an EDV.
    *
    * @param {Object} options - The options to use.
-   * @param {string} options.id the EDV's ID.
+   * @param {string} options.id - The EDV's ID.
    * @param {https.Agent} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    * @param {Object} [options.headers=undefined] - An optional
    *   headers object to use when making requests.
    *
-   * @return {Promise<Object>} resolves to the configuration for the EDV.
+   * @return {Promise<Object>} Resolves to the configuration for the EDV.
    */
   static async getConfig({id, httpsAgent, headers}) {
     // TODO: add `capability` and `invocationSigner` support?
@@ -871,7 +874,7 @@ export class EdvClient {
    * @param {Object} [options.headers=undefined] - An optional
    *   headers object to use when making requests.
    *
-   * @return {Promise<Void>} resolves once the operation completes.
+   * @return {Promise<Void>} Resolves once the operation completes.
    */
   static async updateConfig({id, config, httpsAgent, headers}) {
     // TODO: add `capability` and `invocationSigner` support?
@@ -891,14 +894,14 @@ export class EdvClient {
    * Sets the status of an EDV.
    *
    * @param {Object} options - The options to use.
-   * @param {string} options.id - A EDV ID.
+   * @param {string} options.id - An EDV ID.
    * @param {string} options.status - Either `active` or `deleted`.
    * @param {https.Agent} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    * @param {Object} [options.headers=undefined] - An optional
    *   headers object to use when making requests.
    *
-   * @return {Promise<Void>} resolves once the operation completes.
+   * @return {Promise<Void>} Resolves once the operation completes.
    */
   static async setStatus({id, status, httpsAgent, headers}) {
     // TODO: add `capability` and `invocationSigner` support?

--- a/EdvDocument.js
+++ b/EdvDocument.js
@@ -110,13 +110,14 @@ export class EdvDocument {
    * @param {Object} options.doc - The unencrypted document to update/insert.
    * @return {Promise<Boolean>} resolves to `true` when the document is deleted.
    */
-  async delete(
+  async delete({
     doc, recipients = this.recipients, keyResolver = this.keyResolver
-  ) {
+  } = {}) {
     const {keyAgreementKey, capability, invocationSigner, client} = this;
     return client.delete({
-      doc: doc.doc, recipients, capability, invocationSigner,
-      keyAgreementKey, keyResolver});
+      doc, recipients, capability, invocationSigner,
+      keyAgreementKey, keyResolver
+    });
   }
 }
 

--- a/EdvDocument.js
+++ b/EdvDocument.js
@@ -106,12 +106,17 @@ export class EdvDocument {
   /**
    * Deletes this document from the EDV.
    *
-   * @return {Promise<Boolean>} resolves to `true` if the document was deleted
-   *   and `false` if it did not exist.
+   * @param {Object} options - The options to use.
+   * @param {Object} options.doc - The unencrypted document to update/insert.
+   * @return {Promise<Boolean>} resolves to `true` when the document is deleted.
    */
-  async delete() {
-    const {id, capability, invocationSigner, client} = this;
-    return client.delete({id, capability, invocationSigner});
+  async delete(
+    doc, recipients = this.recipients, keyResolver = this.keyResolver
+  ) {
+    const {keyAgreementKey, capability, invocationSigner, client} = this;
+    return client.delete({
+      doc: doc.doc, recipients, capability, invocationSigner,
+      keyAgreementKey, keyResolver});
   }
 }
 

--- a/tests/10-EdvClient.spec.js
+++ b/tests/10-EdvClient.spec.js
@@ -475,7 +475,7 @@ describe('EdvClient', () => {
     await client.insert({doc, invocationSigner, keyResolver});
     const decrypted = await client.get({id: doc.id, invocationSigner});
     decrypted.should.be.an('object');
-    const result = await client.delete({id: doc.id, invocationSigner,
+    const result = await client.delete({doc: decrypted, invocationSigner,
       keyResolver});
     result.should.equal(true);
     let err;
@@ -490,11 +490,6 @@ describe('EdvClient', () => {
     deletedResult.meta.deleted.should.equal(true);
   });
 
-  it('should fail to delete a non-existent document', async () => {
-    const client = await mock.createEdv();
-    const result = await client.delete({id: 'foo', invocationSigner});
-    result.should.equal(false);
-  });
   it('should increase sequence when updating a deleted document', async () => {
     const client = await mock.createEdv();
     const testId = await EdvClient.generateId();
@@ -502,17 +497,11 @@ describe('EdvClient', () => {
     await client.insert({doc, invocationSigner, keyResolver});
     const decrypted = await client.get({id: doc.id, invocationSigner});
     decrypted.should.be.an('object');
-    await client.delete({id: doc.id, invocationSigner, keyResolver});
+    await client.delete({doc: decrypted, invocationSigner, keyResolver});
     const deletedResult = await client.get({id: doc.id, invocationSigner});
-    deletedResult.content = {someKey: 'someValue'};
-    await client.update({doc: deletedResult, invocationSigner, keyResolver});
-    const updatedResult = await client.get({id: doc.id, invocationSigner});
-    updatedResult.sequence.should.equal(2);
-    updatedResult.content = {anotherKey: 'anotherValue'};
-    await client.update({doc: updatedResult, invocationSigner, keyResolver});
-    const updatedResult2 = await client.get({id: doc.id, invocationSigner});
-    updatedResult2.sequence.should.equal(3);
+    deletedResult.sequence.should.equal(1);
   });
+
   it('should insert a document with attributes', async () => {
     const client = await mock.createEdv();
     client.ensureIndex({attribute: 'content.indexedKey'});

--- a/tests/10-EdvClient.spec.js
+++ b/tests/10-EdvClient.spec.js
@@ -475,7 +475,8 @@ describe('EdvClient', () => {
     await client.insert({doc, invocationSigner, keyResolver});
     const decrypted = await client.get({id: doc.id, invocationSigner});
     decrypted.should.be.an('object');
-    const result = await client.delete({id: doc.id, invocationSigner});
+    const result = await client.delete({id: doc.id, invocationSigner,
+      keyResolver});
     result.should.equal(true);
     let err;
     let deletedResult;
@@ -487,7 +488,6 @@ describe('EdvClient', () => {
     should.not.exist(err);
     should.exist(deletedResult);
     deletedResult.meta.deleted.should.equal(true);
-    deletedResult.jwe.ciphertext.should.equal('');
   });
 
   it('should fail to delete a non-existent document', async () => {
@@ -502,16 +502,16 @@ describe('EdvClient', () => {
     await client.insert({doc, invocationSigner, keyResolver});
     const decrypted = await client.get({id: doc.id, invocationSigner});
     decrypted.should.be.an('object');
-    await client.delete({id: doc.id, invocationSigner});
+    await client.delete({id: doc.id, invocationSigner, keyResolver});
     const deletedResult = await client.get({id: doc.id, invocationSigner});
     deletedResult.content = {someKey: 'someValue'};
     await client.update({doc: deletedResult, invocationSigner, keyResolver});
     const updatedResult = await client.get({id: doc.id, invocationSigner});
-    updatedResult.sequence.should.equal(1);
+    updatedResult.sequence.should.equal(2);
     updatedResult.content = {anotherKey: 'anotherValue'};
     await client.update({doc: updatedResult, invocationSigner, keyResolver});
     const updatedResult2 = await client.get({id: doc.id, invocationSigner});
-    updatedResult2.sequence.should.equal(2);
+    updatedResult2.sequence.should.equal(3);
   });
   it('should insert a document with attributes', async () => {
     const client = await mock.createEdv();

--- a/tests/10-EdvClient.spec.js
+++ b/tests/10-EdvClient.spec.js
@@ -475,8 +475,9 @@ describe('EdvClient', () => {
     await client.insert({doc, invocationSigner, keyResolver});
     const decrypted = await client.get({id: doc.id, invocationSigner});
     decrypted.should.be.an('object');
-    const result = await client.delete({doc: decrypted, invocationSigner,
-      keyResolver});
+    const result = await client.delete({
+      doc: decrypted, invocationSigner, keyResolver
+    });
     result.should.equal(true);
     let err;
     let deletedResult;

--- a/tests/20-EdvDocument.spec.js
+++ b/tests/20-EdvDocument.spec.js
@@ -53,8 +53,9 @@ describe('EdvDocument', () => {
     let err;
     let result;
     try {
-      result = await doc.delete({doc: docResult, invocationSigner,
-        keyResolver});
+      result = await doc.delete({
+        doc: docResult, invocationSigner, keyResolver
+      });
     } catch(e) {
       err = e;
     }

--- a/tests/20-EdvDocument.spec.js
+++ b/tests/20-EdvDocument.spec.js
@@ -32,4 +32,34 @@ describe('EdvDocument', () => {
     result.should.be.an('object');
     result.content.should.deep.equal({indexedKey: 'value1'});
   });
+  it('should delete a document using EdvDocument', async () => {
+    const {invocationSigner, keyResolver} = mock;
+    const client = await mock.createEdv();
+    client.ensureIndex({attribute: 'content.indexedKey'});
+    const doc1Id = await EdvClient.generateId();
+    const doc1 = {id: doc1Id, content: {indexedKey: 'value1'}};
+    await client.insert({doc: doc1, invocationSigner, keyResolver});
+    const doc = new EdvDocument({
+      invocationSigner,
+      id: doc1.id,
+      keyAgreementKey: client.keyAgreementKey,
+      capability: {
+        id: `${client.id}`,
+        invocationTarget: `${client.id}/documents/${doc1.id}`
+      },
+      keyResolver
+    });
+    const docResult = await doc.read();
+    let err;
+    let result;
+    try {
+      result = await doc.delete({doc: docResult, invocationSigner,
+        keyResolver});
+    } catch(e) {
+      err = e;
+    }
+    should.exist(result);
+    should.not.exist(err);
+    result.should.equal(true);
+  });
 });

--- a/tests/MockStorage.js
+++ b/tests/MockStorage.js
@@ -349,12 +349,14 @@ export class MockStorage {
     // delete a document
     server.delete(route, request => {
       const docId = getDocId(request.route);
-      if(!edv.documents.has(docId)) {
+      const doc = edv.documents.get(docId);
+      if(!doc) {
         return [404];
       }
-      const doc = edv.documents.get(docId);
-      this.unindex({edv, doc});
-      edv.documents.delete(docId);
+      doc.indexed = [];
+      doc['deleted'] = true;
+      doc.jwe.ciphertext = '';
+      this.store({edv, doc});
       return [204];
     });
   }

--- a/tests/MockStorage.js
+++ b/tests/MockStorage.js
@@ -345,20 +345,6 @@ export class MockStorage {
       }
       return [200, {json: true}, doc];
     });
-
-    // delete a document
-    server.delete(route, request => {
-      const docId = getDocId(request.route);
-      const doc = edv.documents.get(docId);
-      if(!doc) {
-        return [404];
-      }
-      doc.indexed = [];
-      doc['deleted'] = true;
-      doc.jwe.ciphertext = '';
-      this.store({edv, doc});
-      return [204];
-    });
   }
 }
 


### PR DESCRIPTION
Addresses [#29 in bedrock-edv-storage](https://github.com/digitalbazaar/bedrock-edv-storage/issues/29)

UPDATED:

Deletion has been moved to client-side only. When `edvClient.delete` is called, the content will be emptied and `deleted: true` will be added under the `meta` property. The document will then be passed to `bedrock-edv-storage` via the `update` route.


This PR is dependent on [PR #65](https://github.com/digitalbazaar/bedrock-edv-storage/pull/65) from bedrock-edv-storage.

~~Instead of deleting the doc, some properties are reset:
$set: {'doc.indexed': [], 'doc.deleted': true, 'doc.jwe.ciphertext': ''}~~

~~A deleted edv document is able to be retrieved by the edvClient by id, and will show:
content: {},
meta: { deleted: true }~~

~~It will retain the current sequence number.~~

~~If a document is updated again after it was deleted, it will increment the sequence number as normal, and the deleted property will be removed.~~

