### PR TITLE
Add web-streams-polyfill to deps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # edv-client ChangeLog
 
+## 7.0.1 - TBD
+
+### Added
+- web-streams-polyfill ^2.0.6 to `package.json` to prevent `util.js` from breaking.
+
 ## 7.0.0 - 2020-12-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "esm": "^3.2.22",
     "http-signature-zcap-invoke": "^1.0.0",
     "minimal-cipher": "^1.0.0",
-    "split-string": "^6.1.0"
+    "split-string": "^6.1.0",
+    "web-streams-polyfill": "^2.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",


### PR DESCRIPTION
1. Adds web-streams-polyfill to project deps
2. Addresses: https://github.com/digitalbazaar/edv-client/issues/83

Tests:

1. Passes unit test suites (this is pretty useless as they don't test on edv-storage itself)
2. Passes integration tests in `bedrock-edv-storage`