### PR TITLE
Change index computation to perform blinding in parallel at the end.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @digitalbazaar/edv-client ChangeLog
 
+## 14.0.0 - 2022-05-xx
+
+### Changed
+- **BREAKING**: Blinded attributes (aka encrypted attributes/indexes) are
+  now calculated differently and are incompatible with previous versions. A
+  private `_migrate()` tool has been provided on `EdvClient` that can do
+  basic migration from the old version to the new version, but is very
+  limited to small queries (< 1000 docs) and must be run in a context that
+  ensures unique constraints are not violated but concurrent writes that
+  are external to the migration process. A more robust tool will only be
+  written if it is found to be necessary.
+
 ## 13.0.0 - 2022-03-01
 
 ### Changed

--- a/EdvClient.js
+++ b/EdvClient.js
@@ -586,7 +586,7 @@ export class EdvClient extends EdvClientCore {
 
     const {documents: docs} = await from.find({equals, has, limit: 1000});
     if(docs.length >= 1000) {
-      throw new Error('Too many documents to migrate; limit is 1000.');
+      throw new Error('Too many documents to migrate; limit is 999.');
     }
 
     // update docs in parallel chunks

--- a/EdvClientCore.js
+++ b/EdvClientCore.js
@@ -7,6 +7,7 @@ import {
 } from './assert.js';
 import {Cipher} from '@digitalbazaar/minimal-cipher';
 import {IndexHelper} from './IndexHelper.js';
+import {LegacyIndexHelperVersion1} from './LegacyIndexHelperVersion1.js';
 import {ReadableStream, getRandomBytes} from './util.js';
 
 // 1 MiB = 1048576
@@ -25,10 +26,14 @@ export class EdvClientCore {
    *   API for deriving shared KEKs for wrapping content encryption keys.
    * @param {Function} [options.keyResolver] - A default function that returns
    *   a Promise that resolves a key ID to a DH public key.
+   * @param {string} [options._attributeVersion=2] - Sets the blinded attribute
+   *   version to use; for internal use only.
    *
    * @returns {EdvClientCore}.
    */
-  constructor({hmac, id, keyAgreementKey, keyResolver} = {}) {
+  constructor({
+    hmac, id, keyAgreementKey, keyResolver, _attributeVersion = 2
+  } = {}) {
     if(id !== undefined) {
       assert(id, 'id', 'string');
     }
@@ -37,7 +42,14 @@ export class EdvClientCore {
     this.keyAgreementKey = keyAgreementKey;
     this.keyResolver = keyResolver;
     this.cipher = new Cipher();
-    this.indexHelper = new IndexHelper();
+    if(_attributeVersion === 2) {
+      this.indexHelper = new IndexHelper();
+    } else if(_attributeVersion === 1) {
+      this.indexHelper = new LegacyIndexHelperVersion1();
+    } else {
+      throw new Error(
+        `Unsupported "_attributeVersion" "${_attributeVersion}".`);
+    }
   }
 
   /**

--- a/LegacyIndexHelperVersion1.js
+++ b/LegacyIndexHelperVersion1.js
@@ -8,12 +8,15 @@ import {sha256, TextEncoder} from './util.js';
 
 const ATTRIBUTE_PREFIXES = ['content', 'meta'];
 
-export class IndexHelper {
+export class LegacyIndexHelperVersion1 {
   /**
-   * Creates a new IndexHelper instance that can be used to blind EDV
-   * document attributes to enable indexing.
+   * Creates a new LegacyIndexHelperVersion1 instance that can be used to blind
+   * EDV document attributes to enable indexing.
    *
-   * @returns {IndexHelper}.
+   * This is a legacy version that builds version 1 blinded attributes; it
+   * should only be used when migrating old blinded attributes.
+   *
+   * @returns {LegacyIndexHelperVersion1}.
    */
   constructor() {
     this.indexes = new Map();

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "HttpsTransport.js",
     "IndexHelper.js",
     "index.js",
+    "LegacyIndexHelperVersion1.js",
     "main.js",
     "Transport.js",
     "util-browser.js",

--- a/tests/mock.js
+++ b/tests/mock.js
@@ -60,7 +60,9 @@ export class TestMock {
       this.delegate = await this.createCapabilityAgent();
     }
   }
-  async createEdv({controller, referenceId} = {}) {
+  async createEdv({
+    controller, referenceId, invocationSigner, keyResolver, _attributeVersion
+  } = {}) {
     const {keyAgreementKey, hmac} = this.keys;
     let config = {
       sequence: 0,
@@ -73,7 +75,10 @@ export class TestMock {
     }
     config = await EdvClient.createEdv(
       {config, url: `${BASE_URL}/edvs`});
-    return new EdvClient({id: config.id, keyAgreementKey, hmac});
+    return new EdvClient({
+      id: config.id, keyAgreementKey, hmac,
+      invocationSigner, keyResolver, _attributeVersion
+    });
   }
 
   async createCapabilityAgent() {


### PR DESCRIPTION
Need to add a conversion function to auto-convert any old EDV docs that have any of the attributes provided as a parameter before this can leave draft state.