### PR TITLE
Add base64url-universal to regular deps from devDeps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 15.0.2 -
 
 ###Fixed
-- Moved `base64url-universal` to deps from devDeps
+- Move `base64url-universal` to deps from devDeps.
 
 ## 15.0.1 - 2022-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 15.0.2 -
 
-###Fixed
+### Fixed
 - Move `base64url-universal` to deps from devDeps.
 
 ## 15.0.1 - 2022-08-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/edv-client ChangeLog
 
+## 15.0.2 -
+
+###Fixed
+- Moved `base64url-universal` to deps from devDeps
+
 ## 15.0.1 - 2022-08-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@digitalbazaar/minimal-cipher": "^5.1.1",
     "@digitalbazaar/security-document-loader": "^2.0.0",
     "base58-universal": "^2.0.0",
+    "base64url-universal": "^2.0.0",
     "canonicalize": "^1.0.8",
     "split-string": "^6.1.0"
   },
@@ -38,7 +39,6 @@
     "@digitalbazaar/zcap": "^8.0.0",
     "ajv": "^8.11.0",
     "assert": "^2.0.0",
-    "base64url-universal": "^2.0.0",
     "c8": "^7.11.3",
     "chai": "^4.3.6",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
All tests were passing because `base64url-universal` was in devDeps, but it needs to be in deps as it is used by `lib/Indexhelper.js`